### PR TITLE
Updating Samba4 package

### DIFF
--- a/package/samba4/0002-build-find-pre-built-heimdal-build-tools-in-case-of-.patch
+++ b/package/samba4/0002-build-find-pre-built-heimdal-build-tools-in-case-of-.patch
@@ -75,13 +75,15 @@ index 0ff6dad2f55..f77c177442f 100644
  check_system_heimdal_lib("com_err", "com_right_r com_err", "com_err.h")
  
  if check_system_heimdal_lib("roken", "rk_socket_set_reuseaddr", "roken.h"):
-@@ -96,7 +96,4 @@
+@@ -96,9 +88,6 @@
  #if conf.CHECK_BUNDLED_SYSTEM('tommath', checkfunctions='mp_init', headers='tommath.h'):
  #    conf.define('USING_SYSTEM_TOMMATH', 1)
  
 -check_system_heimdal_binary("compile_et")
 -check_system_heimdal_binary("asn1_compile")
 -
+ conf.env.KRB5_VENDOR = 'heimdal'
  conf.define('USING_SYSTEM_KRB5', 1)
+ conf.define('USING_SYSTEM_HEIMDAL', 1)
 -- 
 2.20.1

--- a/package/samba4/0003-ldap_message_test.c-include-stdint.h-before-cmoka.h.patch
+++ b/package/samba4/0003-ldap_message_test.c-include-stdint.h-before-cmoka.h.patch
@@ -1,0 +1,40 @@
+From b2ea5dc3639d68b878c6534f4992da446dbbf2d4 Mon Sep 17 00:00:00 2001
+From: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Date: Sat, 16 May 2020 18:15:38 +0200
+Subject: [PATCH] ldap_message_test.c: include stdint.h before cmoka.h
+
+This fix the following build failure on uclibc:
+
+In file included from /home/giuliobenetti/autobuild/run/instance-1/output-1/host/opt/ext-toolchain/lib/gcc/mips64el-buildroot-linux-uclibc/5.5.0/include/stdint.h:9:0,
+                 from /home/giuliobenetti/autobuild/run/instance-1/output-1/host/mips64el-buildroot-linux-uclibc/sysroot/usr/include/inttypes.h:27,
+                 from ../../lib/replace/../replace/replace.h:64,
+                 from ../../source4/include/includes.h:23,
+                 from ../../libcli/ldap/tests/ldap_message_test.c:41:
+/home/giuliobenetti/autobuild/run/instance-1/output-1/host/mips64el-buildroot-linux-uclibc/sysroot/usr/include/stdint.h:122:27: error: conflicting types for 'uintptr_t'
+ typedef unsigned long int uintptr_t;
+                           ^
+
+Fixes:
+ - http://autobuild.buildroot.org/results/09e84d15efe755bdefa9f8c6b8355c49ddbc2f65
+
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+[Upstream status: not sent yet]
+---
+ libcli/ldap/tests/ldap_message_test.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libcli/ldap/tests/ldap_message_test.c b/libcli/ldap/tests/ldap_message_test.c
+index c5aacd4bc6b..51331e5c600 100644
+--- a/libcli/ldap/tests/ldap_message_test.c
++++ b/libcli/ldap/tests/ldap_message_test.c
+@@ -34,6 +34,7 @@
+  */
+ #include <stdarg.h>
+ #include <stddef.h>
++#include <stdint.h>
+ #include <setjmp.h>
+ #include <cmocka.h>
+ 
+-- 
+2.26.2
+

--- a/package/samba4/0004-lib-util-Add-signal.h-include.patch
+++ b/package/samba4/0004-lib-util-Add-signal.h-include.patch
@@ -1,0 +1,37 @@
+From d1732a79dbf30c41802245909d0250ebe2b9d92e Mon Sep 17 00:00:00 2001
+From: Bernd Kuhls <bernd.kuhls@t-online.de>
+Date: Sun, 12 Dec 2021 10:27:42 +0100
+Subject: [PATCH] lib/util: Add signal.h include
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes build error with samba-4.15.3 and uClibc:
+
+../../source3/printing/samba-bgqd.c: In function ‘main’:
+../../source3/printing/samba-bgqd.c:340:21: error: ‘SIGPIPE’ undeclared (first use in this function); did you mean ‘EPIPE’?
+../../source3/printing/samba-bgqd.c:384:14: error: ‘SIGTERM’ undeclared (first use in this function)
+
+Patch sent upstream:
+https://gitlab.com/samba-team/samba/-/merge_requests/2296
+
+Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
+---
+ lib/util/signal.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/util/signal.h b/lib/util/signal.h
+index 0663af6ab94..f662ee110d6 100644
+--- a/lib/util/signal.h
++++ b/lib/util/signal.h
+@@ -21,6 +21,7 @@
+ #ifndef _SAMBA_UTIL_SIGNAL_H_
+ #define _SAMBA_UTIL_SIGNAL_H_
+ 
++#include <signal.h>
+ #include <stdbool.h>
+ 
+ /**
+-- 
+2.30.2
+

--- a/package/samba4/samba4-cache.txt
+++ b/package/samba4/samba4-cache.txt
@@ -43,3 +43,4 @@ Checking for a 64-bit host to support lmdb: NO
 Checking value of GNUTLS_CIPHER_AES_128_CFB8: 29
 Checking value of GNUTLS_MAC_AES_CMAC_128: 203
 Checking whether fcntl supports flags to send direct I/O availability signals: OK
+Checking for gnutls fips mode support: NO

--- a/package/samba4/samba4.hash
+++ b/package/samba4/samba4.hash
@@ -1,4 +1,4 @@
 # Locally calculated after checking pgp signature
-# https://download.samba.org/pub/samba/stable/samba-4.14.7.tar.asc
-sha256  6f50353f9602aa20245eb18ceb00e7e5ec793df0974aebd5254c38f16d8f1906  samba-4.14.7.tar.gz
+# https://download.samba.org/pub/samba/stable/samba-4.15.3.tar.asc
+sha256  519399404391550345846768ea4dd0fe7fcb04e20c2b891b5eeb02e5554137db  samba-4.15.3.tar.gz
 sha256  8ceb4b9ee5adedde47b31e975c1d90c73ad27b6b165a1dcd80c7c545eb65b903  COPYING

--- a/package/samba4/samba4.mk
+++ b/package/samba4/samba4.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SAMBA4_VERSION = 4.14.7
+SAMBA4_VERSION = 4.15.3
 SAMBA4_SITE = https://download.samba.org/pub/samba/stable
 SAMBA4_SOURCE = samba-$(SAMBA4_VERSION).tar.gz
 SAMBA4_INSTALL_STAGING = YES


### PR DESCRIPTION
**Core Issue:** 
Samba4 has a CVE vulnerability with the version we use. 

**Best Solution:**
Pulling an updated version of the package from the buildroot's original master branch to update Samba4 to buildroot's current version. 

Fixes https://github.com/ccxtechnologies/builder/issues/1100
