### PR TITLE
Added patch to dhcp buildroot

### DIFF
--- a/package/dhcp/0001-masked-operation-not-permitted-fallback.patch
+++ b/package/dhcp/0001-masked-operation-not-permitted-fallback.patch
@@ -1,0 +1,26 @@
+diff --git a/client/dhclient.c b/client/dhclient.c
+index 46dc3a71..9105c1cf 100644
+--- a/client/dhclient.c
++++ b/client/dhclient.c
+@@ -2992,7 +2992,7 @@ void send_request (cpp)
+ 				     client->packet_length, from, &destination,
+ 				     NULL);
+ 		if (result < 0) {
+-			log_error("%s:%d: Failed to send %d byte long packet "
++			log_info("%s:%d: Failed to send %d byte long packet "
+ 				  "over %s interface.", MDL,
+ 				  client->packet_length,
+ 				  fallback_interface->name);
+diff --git a/common/socket.c b/common/socket.c
+index 3953eac3..3aa00ed8 100644
+--- a/common/socket.c
++++ b/common/socket.c
+@@ -749,7 +749,7 @@ ssize_t send_packet (interface, packet, raw, len, from, to, hto)
+ 		 retry++ < 10);
+ #endif
+ 	if (result < 0) {
+-		log_error ("send_packet: %m");
++		log_info ("send_packet: %m");
+ 		if (errno == ENETUNREACH)
+ 			log_error ("send_packet: please consult README file%s",
+ 				   " regarding broadcast address.");


### PR DESCRIPTION
**Issue:** Noisy error messages appearing on shutdown

**Solution:**
- Added a patch

1) clone dhcp git repo
2) make edits to the dhcp repo
3) pipe git diff to file using `git diff > sendpacketpatch0001.patch`
4) add patch to buildroot's package for dhcp

**Testing**
1) Removed dhcp package from build in output and rebuilt the dhcp
2) Checked for the patch to apply
3) Checked the DHCP package in the output folder
4) Created upgrade with the patch applied
5) Upgraded system to new build
6) Created a bridge network with the two test ports
7) Rebooted the system 5 times to test for the message and monitor the dhclient logs

**Screenshots**
- Confirmation of line change after patch:
![image](https://user-images.githubusercontent.com/110474660/235978089-b39c7c59-df7c-4da7-82e5-29abc91494b3.png)
- Build logs for the partial build showing the patch applied:
![image](https://user-images.githubusercontent.com/110474660/235978206-42400895-6230-403e-8710-ce39ecfb042a.png)
[Complete build logs](https://github.com/ccxtechnologies/buildroot/files/11384757/patchbuild.log)
- dhclient logs:
![image](https://user-images.githubusercontent.com/110474660/235978312-613a4e37-d9bf-4cff-97be-33cdebdc0757.png)

