### PR TITLE
add patch to fix race condition when creating cgroups

### DIFF
--- a/package/lxc/0002-src-lxc-pam-pam_cgfs.c-race-condition-fix.patch
+++ b/package/lxc/0002-src-lxc-pam-pam_cgfs.c-race-condition-fix.patch
@@ -1,0 +1,12 @@
+--- lxc-5.0.3/src/lxc/pam/pam_cgfs.c.orig	2024-11-28 10:51:55.579898623 -0500
++++ lxc-5.0.3/src/lxc/pam/pam_cgfs.c	2024-11-28 10:55:47.059202994 -0500
+@@ -226,6 +226,9 @@
+ 			goto next;
+ 
+ 		if (do_mkdir(path, 0755) < 0) {
++			if (errno == EEXIST) {
++				goto next;
++			}
+ 			pam_cgfs_debug("Failed to create %s: %s\n", path, strerror(errno));
+ 			return false;
+ 		}


### PR DESCRIPTION
**Issue:** https://github.com/ccxtechnologies/builder/issues/4522
race condition - it is possible that another process created a directory after current process confirmed that directory doesn't exist but before it created it, which results in "Failed to create a cgroup" error for the current process.

**Solution:**
Check returned error when trying to create a directory and if it is "File exists" error - continue creating directory and (if necessary) its parents.

**Testing:**
1. making sure build is successful and includes patch:

![Screenshot From 2024-11-28 11-18-03](https://github.com/user-attachments/assets/ab460f8e-b391-41d3-9689-3a46f9687a0b)

in builder/output - fix included in lxc-5.0.3:
![image](https://github.com/user-attachments/assets/068211c3-5800-4ab5-9b61-e5439f93125b)

2. created upgrade file and upgraded router - no new errors (the 4 errors are known errors for this unit, ticket opened in cyberlab):

![image](https://github.com/user-attachments/assets/714e9421-80fc-43d9-91bd-8c4e76c561de)

3. cgroups are created for each user (ntp, falcon, postgres):

![image](https://github.com/user-attachments/assets/2f3649fb-b8d4-4221-8b57-c093ff2bec35)

4. structure is as expected - each user session is under ccxsystem.service -> user

```
id-SUJOYQFT pts/0 ~ -> systemd-cgls
CGroup /:
-.slice
├─init.scope
│ └─1 /sbin/init
├─system.slice
│ ├─systemd-udevd.service …
│ │ └─udev
│ │   └─717 /usr/lib/systemd/systemd-udevd
│ ├─ccxsystem.service
│ │ ├─ 791 /usr/bin/python3.12 /usr/bin/ccxsystemd --system
│ │ ├─ 802 /usr/bin/python3.12 /usr/bin/ccxsystemd --system --subprocess --name system.services
│ │ ├─ 803 /usr/bin/python3.12 /usr/bin/ccxsystemd --system --subprocess --name system.api
│ │ ├─ 804 /usr/bin/python3.12 /usr/bin/ccxsystemd --system --subprocess --name system.network>
...
│ │ ├─3293 systemd-cgls
│ │ ├─3294 less
│ │ └─user
│ │   ├─postgres
│ │   │ └─0
│ │   │   ├─1128 su -s /bin/sh -c LANG=C LC_ALL=C postgres -D /var/lib/ccx/database/postgres ->
│ │   │   ├─1134 postgres -D /var/lib/ccx/database/postgres
│ │   │   ├─1159 postgres: checkpointer
│ │   │   ├─1160 postgres: background writer
...
│ │   │   ├─3105 postgres: writer ccx [local] idle
│ │   │   └─3287 postgres: writer ccx [local] idle
│ │   ├─falcon
│ │   │ └─0
│ │   │   ├─1722 su -s /bin/sh -c /bin/falcon /var/lib/ccx/aeroids/falcon/i01/falcon.config /v>
│ │   │   └─1736 /bin/falcon /var/lib/ccx/aeroids/falcon/i01/falcon.config /var/lib/ccx/aeroid>
│ │   └─ntp
│ │     └─0
│ │       ├─2157 su -s /bin/sh -c /bin/chronyc -g ntp ntp
│ │       └─2160 /bin/chronyc
```

5. Also tested by having race condition on purpose (added sleep after process confirmed that directory doesn't exist but before it creates it) and with added logs. see https://github.com/ccxtechnologies/builder/issues/4522#issuecomment-2504793813